### PR TITLE
change compression method to gzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
-RUN dnf update -y
-RUN dnf install -y autoconf automake libtool
-RUN dnf install -y wget git patch xz ruby
-RUN dnf install -y rpm-build redhat-rpm-config rpmdevtools
+RUN yum update -y
+RUN yum install -y autoconf automake libtool
+RUN yum install -y wget git patch xz ruby
+RUN yum install -y rpm-build redhat-rpm-config rpmdevtools
 
 # Install Zig
 ENV ZIG_VERSION 0.9.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM centos:7
 RUN dnf update -y
 RUN dnf install -y autoconf automake libtool
 RUN dnf install -y wget git patch xz ruby

--- a/rpmbuild/SPECS/mitamae.spec
+++ b/rpmbuild/SPECS/mitamae.spec
@@ -1,7 +1,7 @@
 Summary: mitamae is a fast, simple, and single-binary configuration management tool with a DSL like Chef
 Name: mitamae
 Version: 1.14.0
-Release: 4
+Release: 5
 URL: https://github.com/itamae-kitchen/mitamae
 Source0: https://github.com/itamae-kitchen/mitamae/archive/refs/tags/v%{version}.tar.gz
 Patch0: pull-126-bump-specinfra-v2.87.0.patch
@@ -46,6 +46,9 @@ rm -rf %{buildroot}
 %{_bindir}/mitamae
 
 %changelog
+* Sat Oct 28 2023 ICHINOSE Shogo <shogo82148@gmail.com> - 1.14.0-5
+- change compression method to gzip
+
 * Sat Oct 28 2023 ICHINOSE Shogo <shogo82148@gmail.com> - 1.14.0-4
 - fix aaarch64 build not uploading
 


### PR DESCRIPTION
ZStd is not available on Amazon Linux 2

```
Downloading packages:
Running transaction check
エラー: RPM の更新のためのハンドルを更新する必要があります
rpmlib(PayloadIsZstd) <= 5.4.18-1 is needed by mitamae-1.14.0-4.x86_64
更新には RPM が必要です
 これらを試行できます: rpm -Va --nofiles --nodigest
Your transaction was saved, rerun it with:
 yum load-transaction /tmp/yum_save_tx.2023-10-30.04-41.Pot0He.yumtx
```