### PR TITLE
use gzip instead of ztsd.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,14 @@ ARG PLATFORM
 WORKDIR /root
 RUN rpmdev-setuptree
 COPY ./rpmbuild/ rpmbuild/
+
+# use gzip instead of ztsd.
+# some old distro does not support zstd.
+# ref. https://www.reddit.com/r/openSUSE/comments/qhrzua/rpmbuild_takes_ages_different_algorithm/
+# ref. https://github.com/shogo82148/mitamae-rpm/issues/25
+RUN echo "%_source_payload w9.gzdio" >> ~/.rpmmacros
+RUN echo "%_binary_payload w9.gzdio" >> ~/.rpmmacros
+
 RUN cd rpmbuild/SOURCES/ \
     && curl -sSL -O "https://github.com/itamae-kitchen/mitamae/archive/refs/tags/v${VERSION}.tar.gz"
 RUN rpmbuild -ba --target "${PLATFORM}" rpmbuild/SPECS/mitamae.spec


### PR DESCRIPTION
Zstd is not available on Amazon Linux 2

```
Downloading packages:
Running transaction check
エラー: RPM の更新のためのハンドルを更新する必要があります
rpmlib(PayloadIsZstd) <= 5.4.18-1 is needed by mitamae-1.14.0-4.x86_64
更新には RPM が必要です
 これらを試行できます: rpm -Va --nofiles --nodigest
Your transaction was saved, rerun it with:
 yum load-transaction /tmp/yum_save_tx.2023-10-30.04-41.Pot0He.yumtx
```

close https://github.com/shogo82148/mitamae-rpm/issues/25